### PR TITLE
Add pre-migration check for duplicates in umbracoAccessRules table

### DIFF
--- a/PreMigrationHealthChecks/HealthChecks/DuplicateChecks.cs
+++ b/PreMigrationHealthChecks/HealthChecks/DuplicateChecks.cs
@@ -36,6 +36,16 @@ namespace PreMigrationHealthChecks.HealthChecks
                 ErrorMessage = "Duplicate cmsTags",
                 ErrorDescription = "cmsTags contains {0} rows for duplicate group/tag",
                 FixDescription = "Delete {0} rows in cmsTags"
+            },
+
+            new SqlCheck
+            {
+                Key = "umbracoAccessRule",
+                TestQuery = "SELECT COUNT(*) FROM umbracoAccessRule WHERE id NOT IN (SELECT MIN(id) FROM umbracoAccessRule GROUP BY [ruleValue], [accessId] HAVING MIN(id) IS NOT NULL)",
+                FixQuery = "DELETE FROM umbracoAccessRule WHERE id NOT IN (SELECT MIN(id) FROM umbracoAccessRule GROUP BY [ruleValue], [accessId] HAVING MIN(id) IS NOT NULL)",
+                ErrorMessage = "Duplicate umbracoAccessRules",
+                ErrorDescription = "umbracoAccessRule contains {0} rows for duplicate accessId/ruleValue - content/memberGroup",
+                FixDescription = "Delete {0} rows in umbracoAccessRule"
             }
         };
     }


### PR DESCRIPTION
Ran into this on a migration, where there were duplicate values 'somehow' in the umbracoAccessRules table for an access node id to ruleValue (member group name) mapping - that halted migration when the unique index was applied during the migration to V8.

This PR just provides the same SQL pre check on the table, and allows the duplications to be deleted in the same format as you already have for cmsTags and cmsPropertyData.