### PR TITLE
Render a SELECT query for each check so you can view the data first

### DIFF
--- a/PreMigrationHealthChecks/ForeignKeyViolationCheck.cs
+++ b/PreMigrationHealthChecks/ForeignKeyViolationCheck.cs
@@ -26,14 +26,15 @@ namespace PreMigrationHealthChecks
 
         public override Status GetStatus(Database db)
         {
-            int count = db.ExecuteScalar<int>($"SELECT COUNT(*) FROM {ChildTable} WHERE {ChildColumn} NOT IN (SELECT {ParentColumn} FROM {ParentTable})");
+            string query = $"SELECT COUNT(*) FROM {ChildTable} WHERE {ChildColumn} NOT IN (SELECT {ParentColumn} FROM {ParentTable})";
+            int count = db.ExecuteScalar<int>(query);
             if (count > 0)
             {
                 return new Status
                 {
                     CanFix = true,
                     Message = "Foreign key violation in " + ChildTable,
-                    Description = $"{ChildTable} contains {count} {ChildColumn} values which don't exist in {ParentTable}.{ParentColumn}.",
+                    Description = $"{ChildTable} contains {count} {ChildColumn} values which don't exist in {ParentTable}.{ParentColumn}.<div class='umb-healthcheck-group__details-status-action'>{query.Replace("COUNT(*)", "TOP 100 *")}</div>",
                     FixDescription = $"Delete {count} rows from {ChildTable}"
                 };
             }

--- a/PreMigrationHealthChecks/SqlCheck.cs
+++ b/PreMigrationHealthChecks/SqlCheck.cs
@@ -22,6 +22,8 @@ namespace PreMigrationHealthChecks
             int result = db.ExecuteScalar<int>(TestQuery);
             if (result > 0)
             {
+                ErrorDescription = string.Concat(ErrorDescription,
+                    $"<div class='umb-healthcheck-group__details-status-action'>{TestQuery.Replace("COUNT(*)", "TOP 100 *")}</div>");
                 return new Status
                 {
                     Message = String.Format(ErrorMessage, result),


### PR DESCRIPTION
I ~~needed~~ wanted to check the data first before blindly clicking the `Fix` button so this will output the select query so that you can copy and paste it into your place of choice to execute and view the data first.

I did consider outputting the content in the view but I have 6000+ records in one case so not an option.